### PR TITLE
Fix notice sync pull request token

### DIFF
--- a/.github/workflows/sync-litovel-notices.yml
+++ b/.github/workflows/sync-litovel-notices.yml
@@ -130,7 +130,7 @@ jobs:
         if: steps.scan.outputs.found == 'true' && steps.scan.outputs.dry_run != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LITOVLE_CZ_PAT }}
           path: usneseni-mesta
           branch: litovel-notice-sync/${{ github.run_id }}
           delete-branch: true
@@ -159,6 +159,7 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           existing=$(gh issue list \


### PR DESCRIPTION
Use the existing PAT for automated usneseni-mesta pull requests so the sync workflow is not blocked by repository settings that prevent GITHUB_TOKEN from opening PRs. Also set GH_REPO for the failure issue step so gh can run outside a checkout directory.