### PR TITLE
Assign generated notice sync PRs

### DIFF
--- a/.github/workflows/sync-litovel-notices.yml
+++ b/.github/workflows/sync-litovel-notices.yml
@@ -137,7 +137,7 @@ jobs:
           title: Sync Litovel notices
           commit-message: Sync Litovel notices
           body: ${{ steps.pr_body.outputs.body }}
-          reviewers: honza-kasik
+          assignees: honza-kasik
           add-paths: |
             resources
             work
@@ -153,7 +153,7 @@ jobs:
           title: Sync Litovel notices
           commit-message: Sync generated Litovel notice export
           body: ${{ steps.pr_body.outputs.body }}
-          reviewers: honza-kasik
+          assignees: honza-kasik
 
       - name: Create failure issue
         if: failure()


### PR DESCRIPTION
Assign honza-kasik on generated notice sync pull requests instead of requesting review, because GitHub rejects review requests from the pull request author when the PAT creates the PR.