### PR TITLE
Request review on bot-authored sync PRs

### DIFF
--- a/.github/workflows/sync-litovel-notices.yml
+++ b/.github/workflows/sync-litovel-notices.yml
@@ -137,7 +137,7 @@ jobs:
           title: Sync Litovel notices
           commit-message: Sync Litovel notices
           body: ${{ steps.pr_body.outputs.body }}
-          assignees: honza-kasik
+          reviewers: honza-kasik
           add-paths: |
             resources
             work
@@ -153,7 +153,7 @@ jobs:
           title: Sync Litovel notices
           commit-message: Sync generated Litovel notice export
           body: ${{ steps.pr_body.outputs.body }}
-          assignees: honza-kasik
+          reviewers: honza-kasik
 
       - name: Create failure issue
         if: failure()


### PR DESCRIPTION
Switch generated notice sync pull requests back from assignees to reviewers now that LITOVLE_CZ_PAT is owned by the robot-honza machine account.